### PR TITLE
Adding the ability to use path-match in the whitelist array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { Unauthorized } from '@curveball/http-errors';
 import { OAuth2, OAuth2Options } from 'fetch-mw-oauth2';
 import { default as fetch, Headers, Request, Response } from 'node-fetch';
 import qs from 'querystring';
+// @ts-ignore: Ignore not having this definition for now
+import pathMatch from 'path-match';
 
 // Registering Fetch as a glboal polyfill
 (<any> global).fetch = fetch;
@@ -85,7 +87,9 @@ export default function(options: Options): Middleware {
 
     // Lets first check the whitelist.
     for (const whiteItem of options.whitelist) {
-      if (ctx.path === whiteItem || ctx.path.startsWith(whiteItem + '/')) {
+      const match = pathMatch()(whiteItem);
+
+      if (match(ctx.path) || ctx.path.startsWith(whiteItem + '/')) {
         // It was in the whitelist
         return next();
       }


### PR DESCRIPTION
### Scenario

Imagine having a website where part of the site is dynamic but still required to be public (not requiring authentication) Currently this would require manually restarting/editing the `whitelist` option since it is a simple string check. This is somewhat possible by setting the top level path `/some/path` allowing public access to _all_ of the subpaths beyond that (e.g. `/some/path/that/is/open`)

I have a situation where I need to protect information about our customers, so sharing the entire collection `/merchant` is not feasible. I also want to allow public access to the clients menus, `/merchant/X/menu` but I cant do this with the whitelist today.

### Changes

I've added the `path-match` library to enable parameterized whitelabel, essentially wildcard whitelabels.
