### PR TITLE
Adding the ability to use path matching for whitelists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1597,6 +1597,17 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
       }
     },
     "node-environment-flags": {
@@ -1940,13 +1951,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      }
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+      "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
     },
     "pathval": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   "dependencies": {
     "@curveball/http-errors": "^0.3.0",
     "fetch-mw-oauth2": "^0.4.2",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.0",
+    "path-to-regexp": "^6.2.0"
   },
   "peerDependencies": {
     "@curveball/core": ">=0.9 <1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { Unauthorized } from '@curveball/http-errors';
 import { OAuth2, OAuth2Options } from 'fetch-mw-oauth2';
 import { default as fetch, Headers, Request, Response } from 'node-fetch';
 import qs from 'querystring';
+// @ts-ignore: Ignore not having this definition for now
+import { pathToRegexp } from 'path-to-regexp';
 
 // Registering Fetch as a glboal polyfill
 (<any> global).fetch = fetch;
@@ -85,7 +87,10 @@ export default function(options: Options): Middleware {
 
     // Lets first check the whitelist.
     for (const whiteItem of options.whitelist) {
-      if (ctx.path === whiteItem || ctx.path.startsWith(whiteItem + '/')) {
+      const basePattern = pathToRegexp(whiteItem);
+      const subPattern = pathToRegexp(whiteItem + '/', [], { end: false });
+
+      if (basePattern.test(ctx.path) || subPattern.test(ctx.path)) {
         // It was in the whitelist
         return next();
       }


### PR DESCRIPTION
### Scenario

Imagine having a website where part of the site is dynamic but still required to be public (not requiring authentication) Currently this would require manually restarting/editing the `whitelist` option since it is a simple string check. This is somewhat possible by setting the top level path `/some/path` allowing public access to _all_ of the subpaths beyond that (e.g. `/some/path/that/is/open`)

I have a situation where I need to protect information about our customers, so sharing the entire collection `/merchant` is not feasible. I also want to allow public access to the clients menus, `/merchant/X/menu` but I cant do this with the whitelist today.

### Changes

I've added the `path-to-regexp` library to enable parameterized whitelabel, essentially wildcard whitelabels.

All previous behaviours should continue to act the same, where `/path` will match all subpaths `/path/here`. 