### PR TITLE
Always check authentication header if it's there.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If the token was not valid, it will emit a 401 response.
 Installation
 ------------
 
-    npm install @curveball/oauth2 fetch-mw-oauth2@2
+    npm install @curveball/oauth2@0.3 fetch-mw-oauth2@2
 
 
 Getting started
@@ -39,7 +39,7 @@ const client = OAuth2Client({
 
 const app = new Application();
 app.use(oauth2({
-  whitelist: [
+  publicPrefixes: [
     '/health-check',
     '/login',
     '/register'

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,10 @@ type Options = {
    * /register/foo
    * /register/foo/bar
    */
-  excludeList?: string[];
+  publicPrefixes?: string[];
 
   /**
-   * @deprecated use excludeList instead
+   * @deprecated use publicPrefixes instead
    */
   whitelist?: string[];
 
@@ -37,16 +37,16 @@ type Options = {
 
 export default function(options: Options): Middleware {
 
-  const excludeList = options.excludeList ?? options.whitelist ?? [];
+  const publicPrefixes = options.publicPrefixes ?? options.whitelist ?? [];
 
   return async (ctx, next) => {
 
     let authRequired = true;
 
-    // Lets first check the excludeList
-    for (const whiteItem of excludeList) {
-      if (ctx.path === whiteItem || ctx.path.startsWith(whiteItem + '/')) {
-        // If the current URL is in the excludeList, authentication is optional.
+    // Lets first check the publicPrefixes
+    for (const prefix of publicPrefixes) {
+      if (ctx.path === prefix || ctx.path.startsWith(prefix + '/')) {
+        // If the current URL is in the publicPrefixes, authentication is optional.
         authRequired = false;
         break;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,43 +26,61 @@ type Options = {
    * /register/foo
    * /register/foo/bar
    */
-  whitelist: string[];
+  excludeList?: string[];
+
+  /**
+   * @deprecated use excludeList instead
+   */
+  whitelist?: string[];
 
 };
 
 export default function(options: Options): Middleware {
 
+  const excludeList = options.excludeList ?? options.whitelist ?? [];
+
   return async (ctx, next) => {
 
-    // Lets first check the whitelist.
-    for (const whiteItem of options.whitelist) {
+    let authRequired = true;
+
+    // Lets first check the excludeList
+    for (const whiteItem of excludeList) {
       if (ctx.path === whiteItem || ctx.path.startsWith(whiteItem + '/')) {
-        // It was in the whitelist
-        return next();
+        // If the current URL is in the excludeList, authentication is optional.
+        authRequired = false;
+        break;
       }
+
     }
 
-    if (!ctx.request.headers.has('Authorization')) {
-      throw new Unauthorized('A valid Bearer token is required to access this endpoint', 'Bearer');
+    let introspectResult: null | Awaited<ReturnType<typeof options.client.introspect>> = null;
+
+    const authHeader = ctx.request.headers.get('Authorization');
+    if (!authHeader) {
+      if (authRequired) throw new Unauthorized('A valid Bearer token is required to access this endpoint', 'Bearer');
+    } else {
+      const authParts = authHeader.split(' ');
+      if (authParts.length !== 2 || authParts[0].toLowerCase() !== 'bearer') {
+        if (authRequired) throw new Unauthorized('Unsupported authentication method', 'Bearer');
+      } else {
+
+        const bearerToken = authParts[1];
+        introspectResult = await options.client.introspect({
+          accessToken: bearerToken,
+          expiresAt: null,
+          refreshToken: null,
+        });
+
+      }
+
     }
 
-    const authParts = ctx.request.headers.get('Authorization')!.split(' ');
-    if (authParts.length !== 2 || authParts[0].toLowerCase() !== 'bearer') {
-      throw new Unauthorized('Unsupported authentication method', 'Bearer');
+    if (introspectResult) {
+      if (!introspectResult.active) {
+        throw new Unauthorized('Unrecognized or expired access token');
+      }
+      ctx.state.oauth2 = introspectResult;
     }
-
-    const bearerToken = authParts[1];
-
-    const introspectResult = await options.client.introspect({
-      accessToken: bearerToken,
-      expiresAt: null,
-      refreshToken: null,
-    });
-
-    if (!introspectResult.active) {
-      throw new Unauthorized('Unrecognized or expired access token');
-    }
-    ctx.state.oauth2 = introspectResult;
 
     return next();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,10 @@ export default function(options: Options): Middleware {
 
   const publicPrefixes = options.publicPrefixes ?? options.whitelist ?? [];
 
+  if (options.whitelist) {
+    console.warn('[@curveball/oauth2] The "whitelist" option is deprecated. Use "publicPrefixes" instead.');
+  }
+
   return async (ctx, next) => {
 
     let authRequired = true;

--- a/test/test.ts
+++ b/test/test.ts
@@ -15,7 +15,6 @@ describe('OAuth2 middleware', () => {
         clientId: 'foo',
         introspectionEndpoint: 'http://localhost:40666/introspect',
       }),
-      whitelist: [],
     };
 
     const oauth2mw = OAuth2Mw(options);
@@ -23,17 +22,17 @@ describe('OAuth2 middleware', () => {
 
   });
 
-  it('should pass through whitelisted uris', async () => {
+  it('should pass through public URIs', async () => {
 
     const app = getApp();
-    await expectStatus(200, app, '/whitelist');
+    await expectStatus(200, app, '/public');
 
   });
 
-  it('should pass through whitelisted subpath', async () => {
+  it('should pass through public subpath', async () => {
 
     const app = getApp();
-    await expectStatus(200, app, '/whitelist/foo');
+    await expectStatus(200, app, '/public/foo');
 
   });
 
@@ -108,7 +107,7 @@ function getApp(client?: OAuth2Client) {
       clientId: 'foo',
       introspectionEndpoint: 'http://localhost:40666/introspect',
     }),
-    whitelist: ['/whitelist'],
+    excludeList: ['/public'],
   };
 
   const oauth2mw = OAuth2Mw(options);

--- a/test/test.ts
+++ b/test/test.ts
@@ -107,7 +107,7 @@ function getApp(client?: OAuth2Client) {
       clientId: 'foo',
       introspectionEndpoint: 'http://localhost:40666/introspect',
     }),
-    excludeList: ['/public'],
+    publicPrefixes: ['/public'],
   };
 
   const oauth2mw = OAuth2Mw(options);


### PR DESCRIPTION
The OAuth2 package has an option to *not* check authentication for certain public paths. This previously was called 'whitelist', but is renamed to 'publicPrefixes' for future versions.

If a user hit those paths, no authentication would be done.

The change this PR makes is that auth is checked if you are hitting a public path, and you specified an Authorization header.

The benefit is that even for public paths authenticated clients might send auth headers, and it might be useful for applications to know whether or not a user was authenticated or not.